### PR TITLE
agregar dependencias al pom para iniciar con el desarrollo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,38 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security.oauth</groupId>
+			<artifactId>spring-security-oauth2</artifactId>
+			<version>2.3.6.RELEASE</version>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.modelmapper</groupId>
+			<artifactId>modelmapper</artifactId>
+			<version>2.3.2</version>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-oauth2</artifactId>
+			<version>2.1.2.RELEASE</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Se agrego las siguientes dependencias dependencias:

1. lombok
2. spring-cloud-starter-oauth2
3. modelmapper
4. spring-security-test
5. spring-security-oauth2
6. flyway-core
7. spring-boot-devtools 